### PR TITLE
libreoffice无法从javaldx读取路径及中文文件无法打开

### DIFF
--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -81,7 +81,6 @@ class officeViewerlibreOfficeIndex extends Controller {
 
         $tname = substr(end(explode('/', $file)), 0, -strlen('.'.$ext));
         $tfile = $fpath . $tname . '.' . $fname;    // 源文件名.filename.pdf
-
         if(!file_exists($tfile)){
             write_log('cmmand error: '.$script."\n".$out,'error');
         }

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -70,7 +70,7 @@ class officeViewerlibreOfficeIndex extends Controller {
 		$tempPath = $cacheFile;
 		if($GLOBALS['config']['systemOS'] == 'linux' && is_writable('/tmp/')){
 			mk_dir('/tmp/libreOffice');
-			$tempPath = '/tmp/libreOffice'.rand_string(15).'.pdf';
+			$tempPath = '/tmp/libreOffice/'.rand_string(15).'.pdf';
 		}
         $fname = get_path_this($tempPath);
         $fpath = get_path_father($tempPath);

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -147,5 +147,4 @@ class officeViewerlibreOfficeIndex extends Controller {
 		Cache::set($bin, $code);
 		return $code;
 	}
-}
-
+} 

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -44,6 +44,7 @@ class officeViewerlibreOfficeIndex extends Controller {
             $localFile = $plugin->pluginLocalFile($path);	// 下载到本地文件
         }
         $this->convert2pdf($localFile,$tempFile,$ext);
+	
 		if(@file_exists($tempFile)){
 			$cachePath  = IO::move($tempFile,$plugin->cachePath);
 			Cache::set('libreOffice_pdf_'.$fileHash,'yes');
@@ -74,7 +75,6 @@ class officeViewerlibreOfficeIndex extends Controller {
 		}
         $fname = get_path_this($tempPath);
         $fpath = get_path_father($tempPath);
-
         // 转换类型'pdf'改为'新文件名.pdf'，会生成'源文件名.新文件名.pdf'
         $script = 'export HOME=/tmp/libreOffice && ' . $command . ' --headless --invisible --convert-to '.$fname.' "'.$file.'" --outdir '.$fpath;
 		$out = shell_exec($script);

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -44,7 +44,7 @@ class officeViewerlibreOfficeIndex extends Controller {
             $localFile = $plugin->pluginLocalFile($path);	// 下载到本地文件
         }
         $this->convert2pdf($localFile,$tempFile,$ext);
-	
+
 		if(@file_exists($tempFile)){
 			$cachePath  = IO::move($tempFile,$plugin->cachePath);
 			Cache::set('libreOffice_pdf_'.$fileHash,'yes');

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -148,3 +148,4 @@ class officeViewerlibreOfficeIndex extends Controller {
 		return $code;
 	}
 }
+

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -35,7 +35,6 @@ class officeViewerlibreOfficeIndex extends Controller {
 		$fileHash = KodIO::hashPath($info);
 		$convName = "libreOffice_{$ext}_{$fileHash}.pdf";
 		$tempFile = TEMP_FILES . $convName;
-		//$tempFile = iconv("UTF-8","GB2312",$tempFile);
 		if($sourceID = IO::fileNameExist($plugin->cachePath, $convName)){
 			return $this->fileView(KodIO::make($sourceID),$convName);
 		}
@@ -83,7 +82,7 @@ class officeViewerlibreOfficeIndex extends Controller {
         $tname = substr(end(explode('/', $file)), 0, -strlen('.'.$ext));
         $tfile = $fpath . $tname . '.' . $fname;    // 源文件名.filename.pdf
 
-        if(!file_exists(iconv("UTF-8","GBK",$tfile))){
+        if(!file_exists($tfile)){
             write_log('cmmand error: '.$script."\n".$out,'error');
         }
 		move_path($tfile,$cacheFile);

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -147,4 +147,4 @@ class officeViewerlibreOfficeIndex extends Controller {
 		Cache::set($bin, $code);
 		return $code;
 	}
-} 
+}

--- a/plugins/officeViewer/controller/libreOffice/index.class.php
+++ b/plugins/officeViewer/controller/libreOffice/index.class.php
@@ -148,4 +148,3 @@ class officeViewerlibreOfficeIndex extends Controller {
 		return $code;
 	}
 }
-


### PR DESCRIPTION
1.添加了$script = 'export HOME=/tmp，参考https://www.cnpython.com/qa/1290476
2.basename函数不支持中文，改为substr(end(explode('/', $file)), 0, -strlen('.'.$ext))